### PR TITLE
working with totp lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,12 +230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base32"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,12 +508,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -1309,7 +1297,6 @@ dependencies = [
  "serde",
  "tokio",
  "totp-lite",
- "totp-rs",
 ]
 
 [[package]]
@@ -3290,20 +3277,6 @@ checksum = "f8e43134db17199f7f721803383ac5854edd0d3d523cc34dba321d6acfbe76c3"
 dependencies = [
  "digest",
  "hmac",
- "sha1",
- "sha2",
-]
-
-[[package]]
-name = "totp-rs"
-version = "5.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f124352108f58ef88299e909f6e9470f1cdc8d2a1397963901b4a6366206bf72"
-dependencies = [
- "base32",
- "constant_time_eq",
- "hmac",
- "serde",
  "sha1",
  "sha2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ iced = { git = "https://github.com/iced-rs/iced", default-features = false, feat
     "tokio",
     "tiny-skia",
     "image",
-    "debug",     # TODO: Remove this on release
+    "debug",
 ] }
 serde = { version = "1.0.219", features = ["derive"] }
 ron = "0.10.1"
@@ -17,7 +17,6 @@ dirs = "6.0.0"
 tokio = { version = "1.44.2", features = ["fs"] }
 scrypt = "0.11.0"
 aes-gcm = "0.10.3"
-totp-rs = { version = "5.7.0", features = ["serde_support"] }
 totp-lite = "2.0.1"
 fast32 = "1.0.3"
 

--- a/src/screen/vault.rs
+++ b/src/screen/vault.rs
@@ -1,9 +1,8 @@
 use iced::time::Instant;
 use iced::widget::{button, column, container, float, pick_list, row, text, text_input};
 use iced::{Alignment, Element, Length, Padding, Subscription, Task};
-use totp_rs::Algorithm;
 
-use crate::core::entry::{Entry, TOTPConfig};
+use crate::core::entry::{Algorithm, Entry, TOTPConfig};
 
 pub struct Vault {
     state: State,


### PR DESCRIPTION
This pr substitutes totp-rs with totp-lite, which generates the correct TOTP codes. Still some of them do not work properly.