### PR TITLE
improv: autofocus password field on startup

### DIFF
--- a/src/app/screen/unlock.rs
+++ b/src/app/screen/unlock.rs
@@ -57,7 +57,8 @@ impl UnlockDatabase {
                 db_path,
                 inputs: PageInputs::default(),
             },
-            Task::none(),
+            // Focus the password field automatically on startup
+            focus_next(),
         )
     }
 


### PR DESCRIPTION
Hi! Having to press tab every time I started the app to select the password field was annoying so I automated it by simulating this tab press when the unlock screen appears

I'm not very familiar with `iced` so lmk if you need me to change anything! :)